### PR TITLE
better cargo install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Polars CLI
 
+## 🚀 Get started
+
+```bash
+cargo +nightly install polars-cli
+```
+
+Prerequisites
+1. `rustup`: which provides the `cargo` executable. You can get it from the [official website](https://rustup.rs/).
+2. `rustup install nightly` - The `nightly` version of rust, since some of our dependencies use unstable features.
+
+
 ## CLI
 
 **Build from source**

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## 🚀 Get started
 
 ```bash
-cargo +nightly install polars-cli
+cargo +nightly install polars-cli --locked
 ```
 
 Prerequisites

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ cargo +nightly install polars-cli --locked
 ```
 
 Prerequisites
+
 1. `rustup`: which provides the `cargo` executable. You can get it from the [official website](https://rustup.rs/).
 2. `rustup install nightly` - The `nightly` version of rust, since some of our dependencies use unstable features.
-
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # Polars CLI
 
-## 🚀 Get started
+## Installation
+
+Until binaries are available, the only way to install the Polars CLI is by building it from source:
 
 ```bash
-cargo +nightly install polars-cli --locked
+cargo +nightly install --locked polars-cli
 ```
 
-Prerequisites
-
-1. `rustup`: which provides the `cargo` executable. You can get it from the [official website](https://rustup.rs/).
-2. `rustup install nightly` - The `nightly` version of rust, since some of our dependencies use unstable features.
-
-## CLI
-
-**Build from source**
+Alternatively, clone the repository and install the latest version on the main branch:
 
 ```bash
 cargo install --locked --path .
 ```
+
+#### Prerequisites
+
+1. `rustup`: which provides the `cargo` executable. You can get it from the [official website](https://rustup.rs/).
+2. `rustup install nightly` - The `nightly` version of rust, since some of our dependencies use unstable features.
+
+## Usage
 
 ```shell
 $ polars


### PR DESCRIPTION
The current README.md file only shows you how to install from source. This PR adds instructions to install without cloning the repo.