### PR TITLE
build: Pin polars to version rather than git main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +139,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow2"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963fef509b757bcbbf9e5ffa23bcb345614d99f4f6f531f97417b27b8604d389"
+dependencies = [
+ "ahash",
+ "arrow-format",
+ "base64",
+ "bytemuck",
+ "chrono",
+ "dyn-clone",
+ "either",
+ "ethnum",
+ "fallible-streaming-iterator",
+ "foreign_vec",
+ "futures",
+ "getrandom",
+ "hash_hasher",
+ "hashbrown 0.14.1",
+ "lexical-core",
+ "lz4",
+ "multiversion",
+ "num-traits",
+ "parquet2",
+ "regex",
+ "regex-syntax 0.7.5",
+ "rustc_version",
+ "simdutf8",
+ "streaming-iterator",
+ "strength_reduce",
+ "zstd",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,7 +220,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -205,21 +230,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -716,12 +726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +746,12 @@ dependencies = [
  "hashbrown 0.13.2",
  "serde",
 ]
+
+[[package]]
+name = "hash_hasher"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
@@ -777,12 +787,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "home"
@@ -1081,36 +1085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nano-arrow"
-version = "0.1.0"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
-dependencies = [
- "ahash",
- "arrow-format",
- "base64",
- "bytemuck",
- "chrono",
- "dyn-clone",
- "either",
- "ethnum",
- "fallible-streaming-iterator",
- "foreign_vec",
- "futures",
- "getrandom",
- "hashbrown 0.14.1",
- "lexical-core",
- "lz4",
- "multiversion",
- "num-traits",
- "parquet2",
- "rustc_version",
- "simdutf8",
- "streaming-iterator",
- "strength_reduce",
- "zstd",
-]
-
-[[package]]
 name = "now"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,25 +1119,6 @@ checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.3",
- "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1224,12 +1179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,7 +1208,8 @@ dependencies = [
 [[package]]
 name = "polars"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3030de163b9ff2c9dac9a12dcb9be25cc0f2bc7c8e7cd2e4b2592ebed458ce6a"
 dependencies = [
  "getrandom",
  "polars-core",
@@ -1274,13 +1224,14 @@ dependencies = [
 [[package]]
 name = "polars-arrow"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35cd38a64fb389fd990e4efd433a36331c995c981d353bfef83b5de4d87f1828"
 dependencies = [
+ "arrow2",
  "atoi",
  "ethnum",
  "hashbrown 0.14.1",
  "multiversion",
- "nano-arrow",
  "num-traits",
  "polars-error",
  "serde",
@@ -1301,25 +1252,25 @@ dependencies = [
  "polars",
  "reedline",
  "serde",
- "sqlparser",
+ "sqlparser 0.38.0",
  "tmp_env",
 ]
 
 [[package]]
 name = "polars-core"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08367c014c07fa8f141680e024f926cab3a1fe839605a8fcf2223647eb45ca71"
 dependencies = [
  "ahash",
+ "arrow2",
  "bitflags 2.4.0",
- "bytemuck",
  "chrono",
  "comfy-table",
  "either",
  "hashbrown 0.14.1",
  "indexmap",
  "itoap",
- "nano-arrow",
  "num-traits",
  "once_cell",
  "polars-arrow",
@@ -1340,9 +1291,10 @@ dependencies = [
 [[package]]
 name = "polars-error"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b20a09651a299979354945819dc2ce017964b80b916954e9d2ce39002a5f949"
 dependencies = [
- "nano-arrow",
+ "arrow2",
  "regex",
  "thiserror",
 ]
@@ -1350,24 +1302,21 @@ dependencies = [
 [[package]]
 name = "polars-io"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88cf4a89c18a90ac20dfbcdfd19ab50ad4ac5a76fc7bb775d3c28bb738cf1f34"
 dependencies = [
  "ahash",
- "async-trait",
+ "arrow2",
  "bytes",
  "chrono",
  "fast-float",
- "futures",
  "home",
- "itoa",
  "lexical",
  "lexical-core",
  "memchr",
  "memmap2",
- "nano-arrow",
  "num-traits",
  "once_cell",
- "percent-encoding",
  "polars-arrow",
  "polars-core",
  "polars-error",
@@ -1376,41 +1325,35 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
- "ryu",
  "serde",
  "serde_json",
  "simd-json",
  "simdutf8",
- "smartstring",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
 name = "polars-json"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6d5666176d681706aef5a06a57597c83391948b3d958f9fbe9b4cf016527eb8"
 dependencies = [
  "ahash",
- "chrono",
+ "arrow2",
  "fallible-streaming-iterator",
  "hashbrown 0.14.1",
  "indexmap",
- "itoa",
- "nano-arrow",
  "num-traits",
  "polars-arrow",
  "polars-error",
  "polars-utils",
- "ryu",
  "simd-json",
- "streaming-iterator",
 ]
 
 [[package]]
 name = "polars-lazy"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5110eab438848c981cc5f541fbc5b21bb263fd707000b4715233074fb2630fcf"
 dependencies = [
  "ahash",
  "bitflags 2.4.0",
@@ -1433,22 +1376,17 @@ dependencies = [
 [[package]]
 name = "polars-ops"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7740d7bc4c2ca08044f9ef599638e116fdd7d687e80d1974b698e390c6ce4252"
 dependencies = [
- "ahash",
  "argminmax",
- "bytemuck",
+ "arrow2",
  "either",
- "hashbrown 0.14.1",
  "indexmap",
  "memchr",
- "nano-arrow",
- "num-traits",
  "polars-arrow",
  "polars-core",
- "polars-error",
  "polars-utils",
- "rayon",
  "regex",
  "serde",
  "smartstring",
@@ -1458,7 +1396,8 @@ dependencies = [
 [[package]]
 name = "polars-pipe"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f30c5e77c5594ddc958a46fe2e021da2feba9c94e767e1d798bd82ac5a33c3b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
@@ -1480,12 +1419,12 @@ dependencies = [
 [[package]]
 name = "polars-plan"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678cbeb730e29e50f0f8d844102d15454fc6113a74c667eab046c0e4a4322a9e"
 dependencies = [
  "ahash",
- "nano-arrow",
+ "arrow2",
  "once_cell",
- "percent-encoding",
  "polars-arrow",
  "polars-core",
  "polars-io",
@@ -1503,9 +1442,10 @@ dependencies = [
 [[package]]
 name = "polars-row"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c52ef8885b9d13f848839594fbab21ad79fc63f7e11c19cdc2cfe9bb03c313ac"
 dependencies = [
- "nano-arrow",
+ "arrow2",
  "polars-error",
  "polars-utils",
 ]
@@ -1513,26 +1453,27 @@ dependencies = [
 [[package]]
 name = "polars-sql"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d716855267e3516f722287f68cf10e650e33f7197df83a79e680602471456fc"
 dependencies = [
  "polars-arrow",
  "polars-core",
  "polars-lazy",
  "polars-plan",
- "rand",
  "serde",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.36.1",
 ]
 
 [[package]]
 name = "polars-time"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb75a24f11b55a400b52dc19a2a3e949aaaa46a911f99496de4485b1127063"
 dependencies = [
+ "arrow2",
  "atoi",
  "chrono",
- "nano-arrow",
  "now",
  "once_cell",
  "polars-arrow",
@@ -1547,7 +1488,8 @@ dependencies = [
 [[package]]
 name = "polars-utils"
 version = "0.33.2"
-source = "git+https://github.com/pola-rs/polars?branch=main#9524b29de5758ad4228db155fdfdd319e307de62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4a5e743509096322cad39104d56e329fe2748483a3354a0f0c354724f3cef6"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1683,7 +1625,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.0",
 ]
 
 [[package]]
@@ -1694,20 +1636,20 @@ checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.0",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
@@ -1824,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.11.1"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474b451aaac1828ed12f6454a80fe58b940ae2998d10389d41533940a6f641bf"
+checksum = "80ea1dfc2c400965867fc4ddd6f502572be2de2074b39f90984ed15fbdbdd8eb"
 dependencies = [
  "ahash",
  "getrandom",
@@ -1879,13 +1821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
-name = "socket2"
-version = "0.5.4"
+name = "sqlparser"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "2eaa1e88e78d2c2460d78b7dc3f0c08dbb606ab4222f9aff36f420d36e307d87"
 dependencies = [
- "libc",
- "windows-sys",
+ "log",
 ]
 
 [[package]]
@@ -2046,35 +1987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56eb9e5a28c3c4f0a6aa8ea70a8ad2d6c53e4bf364571ce78f57945b6766843"
 dependencies = [
  "rand",
-]
-
-[[package]]
-name = "tokio"
-version = "1.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "num_cpus",
- "pin-project-lite",
- "socket2",
- "windows-sys",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ sqlparser = "0.38"
 tmp_env = "0.1.1"
 
 [dependencies.polars]
-git = "https://github.com/pola-rs/polars"
-branch = "main"
+version = ">=0.33.0"
 features = ["lazy", "sql", "dtype-full", "serde-lazy"]
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
A few reasons for this:

* Cannot publish to crates.io with dependencies pinned to git
* We want to guarantee that the version published to crates.io matches the binary shipped with the GitHub release.

For now, we should just ship a new Polars CLI release with every Rust release, which is about once a month.