### PR TITLE
ci: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      # Latest commit to include with the release. If omitted, use the latest commit on the main branch.
+      sha:
+        description: Commit SHA
+        type: string
+      # Build binaries, but do not publish to crates.io / GitHub.
+      dry-run:
+        description: Dry run
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is-prerelease: ${{ steps.version.outputs.is_prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+      - name: Get version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep -m 1 -oP 'version = "\K[^"]+' Cargo.toml)
+          if [[ "$VERSION" == *"-"* ]]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+
+  build-binaries:
+    needs: get-version
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: [x86_64, aarch64]
+        exclude:
+          - os: windows-latest
+            arch: aarch64
+          - os: ubuntu-latest
+            arch: aarch64
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
+      # Avoid potential out-of-memory errors
+      - name: Set swap space for Linux
+        if: matrix.os == 'ubuntu-latest'
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
+      - name: Set Rust target
+        id: target
+        run: |
+          if [ ${{ matrix.os == 'ubuntu-latest'}} = true ]; then
+            VENDOR_SYS=unknown-linux-gnu
+          elif [ ${{ matrix.os == 'macos-latest'}} = true ]; then
+            VENDOR_SYS=apple-darwin
+          else
+            VENDOR_SYS=pc-windows-msvc
+          fi
+          TARGET=${{ matrix.arch }}-$VENDOR_SYS
+          echo "target=$TARGET" >> $GITHUB_OUTPUT
+
+      - name: Add rustup target
+        run: rustup target add ${{ steps.target.outputs.target }}
+
+      - name: Set RUSTFLAGS for x86_64
+        if: matrix.arch == 'x86_64' && matrix.os != 'macos-latest'
+        run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt" >> $GITHUB_ENV
+      - name: Set RUSTFLAGS for x86_64 MacOS
+        if: matrix.arch == 'x86_64' && matrix.os == 'macos-latest'
+        run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma" >> $GITHUB_ENV
+
+      - name: Set jemalloc for aarch64 Linux
+        if: matrix.arch == 'aarch64' && matrix.os == 'ubuntu-latest'
+        run: echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
+
+      - name: Build binary
+        run: cargo build --target ${{ steps.target.outputs.target }} --release
+
+      - name: Test binary
+        if: matrix.arch == 'x86_64'
+        run: ./target/${{ steps.target.outputs.target }}/release/polars --version
+
+      - name: Archive binary
+        id: archive
+        run: |
+          ARCHIVE_FILENAME=polars-cli-${{ needs.get-version.outputs.version }}-${{ steps.target.outputs.target }}.tar.gz
+          DIR=target/${{ steps.target.outputs.target }}/release
+          tar czvf $ARCHIVE_FILENAME --directory=$DIR polars
+          echo "filename=$ARCHIVE_FILENAME" >> $GITHUB_OUTPUT
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: ${{ steps.archive.outputs.filename }}
+
+  publish-to-crates-io:
+    needs: build-binaries
+    environment:
+      name: release
+      url: https://crates.io/crates/polars-cli
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish ${{ inputs.dry-run && '--dry-run' || '' }}
+
+  publish-to-github:
+    needs: [publish-to-crates-io, get-version]
+    environment:
+      name: release
+      url: https://github.com/pola-rs/polars-cli/releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: binaries
+          path: binaries
+
+      # TODO: Publish only after uploading binaries
+      - name: Create and publish GitHub release
+        id: github-release
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+          name: ${{ needs.get-version.outputs.version }}
+          tag: ${{ needs.get-version.outputs.version }}
+          version: ${{ needs.get-version.outputs.version }}
+          prerelease: ${{ needs.get-version.outputs.is-prerelease }}
+          commitish: ${{ inputs.sha }}
+          publish: ${{ inputs.dry-run == false }}
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload binaries to GitHub release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: binaries/*
+          file_glob: true
+          tag: ${{ steps.github-release.outputs.tag_name }}
+          overwrite: true


### PR DESCRIPTION
This allows releasing new versions to crates.io and create a GitHub release including binaries.