### PR TITLE
ci: Use app token

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -34,10 +34,16 @@ jobs:
           default_author: github_actions
           new_branch: release/${{ steps.version.outputs.version }}
 
+      - name: Generate GitHub token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.CI_APP_ID }}
+          private_key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - name: Open pull request
         env:
-          GH_TOKEN: ${{ secrets.DEPLOY_PAT }}
-        shell: bash
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh pr create \
           --head 'release/${{ steps.version.outputs.version }}' \


### PR DESCRIPTION
Use a token generated by a GitHub App rather than a personal access token.