### PR TITLE
Bump toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-06-03"
+channel = "nightly-2024-11-28"


### PR DESCRIPTION
This brings the toolchain in line with the latest Rust Polars release.